### PR TITLE
Installing COCO API to local user; fixing protoc issue

### DIFF
--- a/tools/datasets/download_and_preprocess_coco.sh
+++ b/tools/datasets/download_and_preprocess_coco.sh
@@ -35,15 +35,22 @@ fi
 sudo apt install -y protobuf-compiler python-pil python-lxml\
   python-pip python-dev git unzip
 
-pip install Cython
-pip install git+https://github.com/cocodataset/cocoapi#subdirectory=PythonAPI
+pip install Cython --user
+pip install git+https://github.com/cocodataset/cocoapi#subdirectory=PythonAPI --user
 
 echo "Cloning Tensorflow models directory (for conversion utilities)"
 if [ ! -e tf-models ]; then
   git clone http://github.com/tensorflow/models tf-models
 fi
 
-(cd tf-models/research && protoc object_detection/protos/*.proto --python_out=.)
+mkdir protoc_3.3
+cd protoc_3.3
+wget https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip
+chmod 775 protoc-3.3.0-linux-x86_64.zip
+unzip protoc-3.3.0-linux-x86_64.zip
+cd ..
+
+(cd tf-models/research && ../../protoc_3.3/bin/protoc object_detection/protos/*.proto --python_out=.)
 
 UNZIP="unzip -nq"
 


### PR DESCRIPTION
Installing COCO API to local user to avoid permission issue;

Also use protoc 3.3.0 to install as in Ubuntu 16.04, the default protoc version is 2.6 which is not compatible with Object Detection API anymore. Otherwise the below error message will be thrown:

```
object_detection/protos/ssd.proto:87:3: Expected "required", "optional", or "repeated".
object_detection/protos/ssd.proto:87:12: Expected field name.
object_detection/protos/model.proto: Import "object_detection/protos/ssd.proto" was not found or had errors.
object_detection/protos/model.proto:12:5: "Ssd" is not defined.
```