### PR TITLE
Fix syntax errors on imports and define unicode in Python 3

### DIFF
--- a/models/experimental/keras/imagenet_input.py
+++ b/models/experimental/keras/imagenet_input.py
@@ -22,7 +22,7 @@ import os
 
 import tensorflow as tf
 
-import resnet_preprocessing/
+import resnet_preprocessing
 
 
 def image_serving_input_fn():

--- a/models/experimental/keras/resnet50.py
+++ b/models/experimental/keras/resnet50.py
@@ -30,7 +30,7 @@ import tensorflow as tf
 import numpy as np
 
 from tensorflow.contrib.tpu.python.tpu import keras_support
-import imagenet_input/
+import imagenet_input
 
 flags.DEFINE_string('tpu', None, 'Name of the TPU to use; if None, use CPU.')
 flags.DEFINE_string('data', None, 'Path to training and testing data.')

--- a/models/experimental/qanet/preprocess.py
+++ b/models/experimental/qanet/preprocess.py
@@ -32,6 +32,12 @@ import tensorflow as tf
 
 import data
 
+try:
+  unicode        # Python 2
+except NameError:
+  unicode = str  # Python 3
+
+
 flags.DEFINE_string('input_path', '', 'Comma separated path to JSON files.')
 flags.DEFINE_integer('max_shard_size', 11000, 'Number of examples per shard.')
 flags.DEFINE_string('output_path', '/tmp', 'TFRecord path/name prefix. ')

--- a/models/experimental/qanet/utils.py
+++ b/models/experimental/qanet/utils.py
@@ -22,6 +22,11 @@ import copy
 import math
 import pprint
 
+try:
+  unicode        # Python 2
+except NameError:
+  unicode = str  # Python 3
+
 
 # TODO(ddohan): FrozenConfig type
 class Config(dict):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/tpu on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./models/experimental/qanet/utils.py:156:30: F821 undefined name 'unicode'
  if tp in [int, float, str, unicode, bool, tuple, list]:
                             ^
./models/experimental/qanet/preprocess.py:58:54: F821 undefined name 'unicode'
    if isinstance(val[0], str) or isinstance(val[0], unicode):
                                                     ^
./models/experimental/qanet/preprocess.py:67:29: F821 undefined name 'unicode'
      if isinstance(val[0], unicode):
                            ^
./models/experimental/keras/resnet50.py:33:22: E999 SyntaxError: invalid syntax
import imagenet_input/
                     ^
./models/experimental/keras/imagenet_input.py:25:28: E999 SyntaxError: invalid syntax
import resnet_preprocessing/
                           ^
2     E999 SyntaxError: invalid syntax
3     F821 undefined name 'unicode'
5
```