### PR TITLE
Fix for issue where ctpu up is not able to create preemptible VM's.

### DIFF
--- a/tools/ctpu/commands/up.go
+++ b/tools/ctpu/commands/up.go
@@ -244,6 +244,7 @@ func (c *upCmd) upVM() error {
 				ImageName:         c.gceImage,
 				MachineType:       c.machineType,
 				DiskSizeGb:        c.diskSizeGb,
+				Preemptible:       c.preemptibleVM,
 			}
 			op, err := c.gce.CreateInstance(req)
 			if err != nil {


### PR DESCRIPTION
Fix for issue where ctpu up is not able to create preemptible VM's.
Github issue: https://github.com/tensorflow/tpu/issues/195