### PR TITLE
Add colab links to Fashion MNIST example

### DIFF
--- a/tools/colab/fashion_mnist.ipynb
+++ b/tools/colab/fashion_mnist.ipynb
@@ -9,6 +9,14 @@
       "source": [
         "# Fashion MNIST with Keras and TPUs\n",
         "\n",
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        " <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tpu/blob/master/tools/colab/fashion_mnist.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tpu/blob/master/tools/colab/fashion_mnist.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>",
         "Let's try out using `tf.keras` and Cloud TPUs to train a model on the fashion MNIST dataset.\n",
         "\n",
         "First, let's grab our dataset using `tf.keras.datasets`."


### PR DESCRIPTION
Since now colab also, supports TPU would make sense to add `Run in Google Colab` link to this tutorial as well