### PR TITLE
Fix some Python 3 compatibility issues

### DIFF
--- a/models/experimental/qanet/preprocess.py
+++ b/models/experimental/qanet/preprocess.py
@@ -28,6 +28,7 @@ import os
 from absl import app
 from absl import flags
 
+from six import string_types, text_type
 import tensorflow as tf
 
 import data
@@ -55,7 +56,7 @@ def get_tf_example(example):
     if not isinstance(val, list):
       val = [val]
 
-    if isinstance(val[0], str) or isinstance(val[0], unicode):
+    if isinstance(val[0], string_types):
       dtype = 'bytes'
     elif isinstance(val[0], int):
       dtype = 'int64'
@@ -64,7 +65,7 @@ def get_tf_example(example):
 
     if dtype == 'bytes':
       # Transform unicode into bytes if necessary.
-      if isinstance(val[0], unicode):
+      if isinstance(val[0], text_type):
         val = [each.encode('utf-8') for each in val]
       feature[key] = tf.train.Feature(bytes_list=tf.train.BytesList(value=val))
     elif dtype == 'int64':

--- a/models/experimental/qanet/utils.py
+++ b/models/experimental/qanet/utils.py
@@ -22,6 +22,8 @@ import copy
 import math
 import pprint
 
+from six import text_type
+
 
 # TODO(ddohan): FrozenConfig type
 class Config(dict):
@@ -153,7 +155,7 @@ def _convert_type(val, tp):
   Raises:
     ValueError: If the conversion fails.
   """
-  if tp in [int, float, str, unicode, bool, tuple, list]:
+  if tp in [int, float, str, text_type, bool, tuple, list]:
     in_type = type(val)
     cast = tp(val)
     if in_type(cast) != val:

--- a/models/experimental/resnet50_keras/eval_utils.py
+++ b/models/experimental/resnet50_keras/eval_utils.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange
 
 
 def multi_top_k_accuracy(model, evaluation_generator, eval_steps, ks=(1, 5)):


### PR DESCRIPTION
Fixes __unicode__ and __xrange()__ issues in [flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/tpu on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./models/experimental/qanet/preprocess.py:58:54: F821 undefined name 'unicode'
    if isinstance(val[0], str) or isinstance(val[0], unicode):
                                                     ^
./models/experimental/qanet/preprocess.py:67:29: F821 undefined name 'unicode'
      if isinstance(val[0], unicode):
                            ^
./models/experimental/qanet/utils.py:156:30: F821 undefined name 'unicode'
  if tp in [int, float, str, unicode, bool, tuple, list]:
                             ^
./models/experimental/distribution_strategy/resnet_keras.py:118:24: F821 undefined name 'weights_file'
    model.save_weights(weights_file, overwrite=True)
                       ^
./models/experimental/resnet50_keras/eval_utils.py:48:12: F821 undefined name 'xrange'
  for _ in xrange(eval_steps):
           ^
./models/experimental/show_and_tell/inputs.py:209:33: F821 undefined name 'input_seq'
    enqueue_list.append([image, input_seq, target_seq, indicator])
                                ^
./models/experimental/show_and_tell/inputs.py:209:44: F821 undefined name 'target_seq'
    enqueue_list.append([image, input_seq, target_seq, indicator])
                                           ^
./models/experimental/show_and_tell/inputs.py:209:56: F821 undefined name 'indicator'
    enqueue_list.append([image, input_seq, target_seq, indicator])
                                                       ^
8     F821 undefined name 'weights_file'
8
```