### PR TITLE
Removed reshape(-1) in set_shapes()

### DIFF
--- a/models/official/resnet/imagenet_input.py
+++ b/models/official/resnet/imagenet_input.py
@@ -73,7 +73,6 @@ class ImageNetTFExampleInput(object):
     if self.transpose_input:
       images.set_shape(images.get_shape().merge_with(
           tf.TensorShape([None, None, None, batch_size])))
-      images = tf.reshape(images, [-1])
       labels.set_shape(labels.get_shape().merge_with(
           tf.TensorShape([batch_size])))
     else:


### PR DESCRIPTION
The line 76 in [tpu/models/official/resnet/imagenet_input.py](https://github.com/tensorflow/tpu/blob/master/models/official/resnet/imagenet_input.py#L76):

```python
images = tf.reshape(images, [-1])
```

It should be removed.