### PR TITLE
update README to latest CLI version

### DIFF
--- a/models/official/resnet/README.md
+++ b/models/official/resnet/README.md
@@ -239,7 +239,7 @@ The default ResNet-50 has been carefully tested with the default flags but
 configurations including ResNet-18, 34, 101, 152, 200. The 18 and 34 layer
 configurations use residual blocks without bottlenecks and the remaining
 configurations use bottleneck layers. The configuration can be controlled via
-`--resnet_size`. Bigger models require more training time and more memory, thus
+`--resnet_depth`. Bigger models require more training time and more memory, thus
 may require lowering the `--train_batch_size` to avoid running out of memory.
 
 ### Using your own data

--- a/models/official/retinanet/README.md
+++ b/models/official/retinanet/README.md
@@ -232,10 +232,10 @@ python tpu/models/official/retinanet/retinanet_main.py  \
  --mode=eval \
  --num_epochs=1 \
  --num_examples_per_epoch=1000 \
- --eval_steps=10
+ --eval_samples=10
 ```
 
-We specified `num_epochs=1` and `eval_steps=10` above to ensure our script
+We specified `num_epochs=1` and `eval_samples=10` above to ensure our script
 finished quickly.  We'll change those now to run over the full evaluation
 dataset:
 
@@ -248,7 +248,7 @@ python tpu/models/official/retinanet/retinanet_main.py  \
  --hparams=image_size=640 \
  --num_epochs=15 \
  --mode=eval \
- --eval_steps=5000
+ --eval_samples=5000
 ```
 
 It takes about 10 minutes to run through the 5000 evaluation steps.  After


### PR DESCRIPTION
`retinanet_main.py` does not use `--eval_steps` anymore. The new CLI is `--eval_samples`.