### PR TITLE
retinanet kubefile: add update step for missing repository

### DIFF
--- a/models/official/retinanet/retinanet_k8s.yaml
+++ b/models/official/retinanet/retinanet_k8s.yaml
@@ -35,6 +35,7 @@ spec:
           - /bin/sh
           - -c
           - >
+            DEBIAN_FRONTEND=noninteractive apt-get update &&
             DEBIAN_FRONTEND=noninteractive apt-get install -y python-dev python-tk &&
             pip install Cython matplotlib &&
             pip install 'git+https://github.com/cocodataset/cocoapi#egg=pycocotools&subdirectory=PythonAPI' &&


### PR DESCRIPTION
current kubefile is erroring out when a repository that is missing returns a 404.

added an update call at the head to split up the refresh/install steps.