### PR TITLE
Enable PREDICT on TPU for retinanet model

### DIFF
--- a/models/official/retinanet/retinanet_model.py
+++ b/models/official/retinanet/retinanet_model.py
@@ -378,7 +378,7 @@ def _model_fn(features, labels, mode, params, model, variable_filter_fn=None):
 
     # Add the computed `top-k` values in addition to the raw boxes.
     add_metric_fn_inputs(params, cls_outputs, box_outputs, predictions)
-    return tf.estimator.EstimatorSpec(mode=mode, predictions=predictions)
+    return tf.contrib.tpu.TPUEstimatorSpec(mode=mode, predictions=predictions)
 
   # Load pretrained model from checkpoint.
   if params['resnet_checkpoint'] and mode == tf.estimator.ModeKeys.TRAIN:


### PR DESCRIPTION
`tf.estimator.EstimatorSpec` returned in case of "PREDICT" mode does not allow for inference on TPU. This is replaced with `tf.contrib.tpu.TPUEstimatorSpec` which allows to do so. Inference on CPU/GPU still works well with this type of spec.