### PR TITLE
Updated to be compatible with python3

### DIFF
--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -99,7 +99,7 @@ def download_dataset(raw_data_dir):
   """Download the Imagenet dataset into the temporary directory."""
   def _download(url, filename):
     """Download the dataset at the provided filepath."""
-    urllib.urlretrieve(url, filename)
+    urllib.request.urlretrieve(url, filename)
 
   def _get_members(filename):
     """Get all members of a tarfile."""
@@ -174,9 +174,9 @@ def _convert_to_example(filename, image_buffer, label, synset, height, width):
   Returns:
     Example proto
   """
-  colorspace = 'RGB'
+  colorspace = b'RGB'
   channels = 3
-  image_format = 'JPEG'
+  image_format = b'JPEG'
 
   example = tf.train.Example(features=tf.train.Features(feature={
       'image/height': _int64_feature(height),
@@ -184,9 +184,9 @@ def _convert_to_example(filename, image_buffer, label, synset, height, width):
       'image/colorspace': _bytes_feature(colorspace),
       'image/channels': _int64_feature(channels),
       'image/class/label': _int64_feature(label),
-      'image/class/synset': _bytes_feature(synset),
+      'image/class/synset': _bytes_feature(synset.encode('ASCII')),
       'image/format': _bytes_feature(image_format),
-      'image/filename': _bytes_feature(os.path.basename(filename)),
+      'image/filename': _bytes_feature(os.path.basename(filename).encode('ASCII')),
       'image/encoded': _bytes_feature(image_buffer)}))
   return example
 
@@ -279,7 +279,7 @@ def _process_image(filename, coder):
     width: integer, image width in pixels.
   """
   # Read the image file.
-  with tf.gfile.FastGFile(filename, 'r') as f:
+  with tf.gfile.FastGFile(filename, 'rb') as f:
     image_data = f.read()
 
   # Clean the dirty data.
@@ -367,7 +367,7 @@ def convert_to_tf_records(raw_data_dir):
   random.seed(0)
   def make_shuffle_idx(n):
     order = range(n)
-    random.shuffle(order)
+    random.shuffle(list(order))
     return order
 
   # Glob all the training files


### PR DESCRIPTION
Vairous fixes to make imagenet_to_gcs.py work with Pythn3:
* bytes versus string
* lazy (sequence) versus eager (list) 
* urilib API changes

P.S. Updated code still compatible wiith python2 (tested with Python 2.7.12