### PR TITLE
Fix error "TypeError: 'str' object does not support item assignment"

### DIFF
--- a/tools/datasets/create_coco_tf_record.py
+++ b/tools/datasets/create_coco_tf_record.py
@@ -50,7 +50,7 @@ flags.DEFINE_boolean('include_masks', False,
 flags.DEFINE_string('image_dir', '', 'Directory containing images.')
 flags.DEFINE_string('image_info_file', '', 'File containing image information. '
                     'Tf Examples in the output files correspond to the image '
-                    'info entries in this file. If this file is not provided ',
+                    'info entries in this file. If this file is not provided '
                     'object_annotations_file is used if present. Otherwise, '
                     'caption_annotations_file is used to get image info.')
 flags.DEFINE_string('object_annotations_file', '', 'File containing object '


### PR DESCRIPTION
Following the following instruction and got this error, and this is the fix
- https://cloud.google.com/tpu/docs/tutorials/mask-rcnn

While running this, the following error occured
```
cd tpu/tools/datasets && \
bash download_and_preprocess_coco.sh ./data/dir/coco
```

``` TypeError: 'str' object does not support item assignment ```

