### PR TITLE
fix typo in efficientnet/README.md

### DIFF
--- a/models/official/efficientnet/README.md
+++ b/models/official/efficientnet/README.md
@@ -61,7 +61,7 @@ Please refer to the following colab for more instructions on how to obtain and u
 
 ```
     import efficientnet_builder
-    features, endpoints = efficientnet_builder.build_model_base(images, 'efficient-b0')
+    features, endpoints = efficientnet_builder.build_model_base(images, 'efficientnet-b0')
 ```
 
   * Use `features` for classification finetuning.


### PR DESCRIPTION
which caused an error `NotImplementedError: model name is not pre-defined: efficient-b[x]` while use as feature extractor