### PR TITLE
Fix imagenet conversion

### DIFF
--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -366,7 +366,7 @@ def convert_to_tf_records(raw_data_dir):
   # across the batches.
   random.seed(0)
   def make_shuffle_idx(n):
-    order = range(n)
+    order = list(range(n))
     random.shuffle(order)
     return order
 

--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -174,9 +174,9 @@ def _convert_to_example(filename, image_buffer, label, synset, height, width):
   Returns:
     Example proto
   """
-  colorspace = 'RGB'
+  colorspace = b'RGB'
   channels = 3
-  image_format = 'JPEG'
+  image_format = b'JPEG'
 
   example = tf.train.Example(features=tf.train.Features(feature={
       'image/height': _int64_feature(height),
@@ -184,9 +184,9 @@ def _convert_to_example(filename, image_buffer, label, synset, height, width):
       'image/colorspace': _bytes_feature(colorspace),
       'image/channels': _int64_feature(channels),
       'image/class/label': _int64_feature(label),
-      'image/class/synset': _bytes_feature(synset),
+      'image/class/synset': _bytes_feature(synset.encode()),
       'image/format': _bytes_feature(image_format),
-      'image/filename': _bytes_feature(os.path.basename(filename)),
+      'image/filename': _bytes_feature(os.path.basename(filename).encode()),
       'image/encoded': _bytes_feature(image_buffer)}))
   return example
 
@@ -279,7 +279,7 @@ def _process_image(filename, coder):
     width: integer, image width in pixels.
   """
   # Read the image file.
-  with tf.gfile.FastGFile(filename, 'r') as f:
+  with tf.gfile.FastGFile(filename, 'rb') as f:
     image_data = f.read()
 
   # Clean the dirty data.


### PR DESCRIPTION
Running Python 3.7.3, the ImageNet-to-GCS script fails with the errors: `TypeError: 'some-string' has type str, but expected one of: bytes`, `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte`, and `TypeError: 'range' object does not support item assignment`. This PR fixes said errors and allows the script to generate TFRecord files.