### PR TITLE
BugFix: error due to multiple config files

### DIFF
--- a/models/official/mask_rcnn/mask_rcnn_main.py
+++ b/models/official/mask_rcnn/mask_rcnn_main.py
@@ -28,6 +28,7 @@ from hyperparameters import params_dict
 import dataloader
 import distributed_executer
 import mask_rcnn_model
+import sys; sys.path.insert(0, 'tpu/models/official/mask_rcnn')
 from configs import mask_rcnn_config
 
 common_tpu_flags.define_common_tpu_flags()


### PR DESCRIPTION
Inside the `mask_rcnn_main.py`, 

```
import dataloader
import distributed_executer
import mask_rcnn_model
from configs import mask_rcnn_config
```

Currently if print `sys.path` before `from configs import mask_rcnn_config`, the `sys.path` is 
```
['tpu/models/official/mnasnet', 'tpu/models/official/mask_rcnn', 'tpu/models', '/usr/lib/python2.7', '/usr/lib/python2.7/plat-x86_64-linux-gnu', '/usr/lib/python2.7/lib-tk', '/usr/lib/python2.7/lib-old', '/usr/lib/python2.7/lib-dynload', '/home/panfeng/.local/lib/python2.7/site-packages', '/usr/local/lib/python2.7/dist-packages', '/usr/lib/python2.7/dist-packages']
```
Where the `tpu/models/official/mnasnet` is from `import mask_rcnn_model`, where

```
import sys
sys.path.insert(0, 'tpu/models/official/mnasnet')
```
is in `mask_rcnn_model.py`.

So Python would first look as `configs` under `tpu/models/official/mnasnet`, which will cause error.

```
import sys; sys.path.insert(0, 'tpu/models/official/mask_rcnn')
from configs import mask_rcnn_config
```
could solve it.