### PR TITLE
BugFix: get_flag_value function not work as designed.

### DIFF
--- a/models/hyperparameters/flags_to_params.py
+++ b/models/hyperparameters/flags_to_params.py
@@ -78,7 +78,10 @@ def get_dictionary_from_flags(params, input_flags):
       d = get_dictionary_from_flags(v, input_flags)
       flag_dict[k] = d
     else:
-      flag_value = input_flags.get_flag_value(k, None)
+      try:
+        flag_value = input_flags.get_flag_value(k, None)
+      except:
+        flag_value = None
 
       if flag_value is not None:
         flag_dict[k] = flag_value


### PR DESCRIPTION
In `flags_to_params.py`, it uses `flag_value = input_flags.get_flag_value(k, None)`, however the `get_flag_value` function not work as designed, it would not return `None` if the `k` is not in the flag's namespace.


Please take a look at https://github.com/abseil/abseil-py/blob/master/absl/flags/_flagvalues.py

```
def get_flag_value(self, name, default):  # pylint: disable=invalid-name
    """Returns the value of a flag (if not None) or a default value.
    Args:
      name: str, the name of a flag.
      default: Default value to use if the flag value is None.
    Returns:
      Requested flag value or default.
    """

    value = self.__getattr__(name)
    if value is not None:  # Can't do if not value, b/c value might be '0' or ""
      return value
    else:
      return default
```

```
def __getattr__(self, name):
    """Retrieves the 'value' attribute of the flag --name."""
    fl = self._flags()
    if name not in fl:
      raise AttributeError(name)
    if name in self.__dict__['__hiddenflags']:
      raise AttributeError(name)

    if self.__dict__['__flags_parsed'] or fl[name].present:
      return fl[name].value
    else:
      error_message = (
          'Trying to access flag --%s before flags were parsed.' % name)
      if six.PY2:
        # In Python 2, hasattr returns False if getattr raises any exception.
        # That means if someone calls hasattr(FLAGS, 'flag'), it returns False
        # instead of raises UnparsedFlagAccessError even if --flag is already
        # defined. To make the error more visible, the best we can do is to
        # log an error message before raising the exception.
        # Don't log a full stacktrace here since that makes other callers
        # get too much noise.
        logging.error(error_message)
      raise _exceptions.UnparsedFlagAccessError(error_message)
```

The `get_flag_value` function cannot handle the case when the `name` is not in flag's namespace.