### PR TITLE
Change depreciated FastGFile with Gfile

### DIFF
--- a/tools/datasets/jpeg_to_tf_record.py
+++ b/tools/datasets/jpeg_to_tf_record.py
@@ -212,7 +212,7 @@ if __name__ == '__main__':
     os.makedirs(OUTPUT_DIR)
 
   # read list of labels
-  with tf.gfile.FastGFile(arguments['labels_file'], 'r') as f:
+  with tf.gfile.GFile(arguments['labels_file'], 'r') as f:
     LABELS = [line.rstrip() for line in f]
   print('Read in {} labels, from {} to {}'.format(
       len(LABELS), LABELS[0], LABELS[-1]))


### PR DESCRIPTION
The FastGFile is [reventing the functionality, so as suggested by the TensorFlow warning it is going to be depreciated and it is not working very well now.