### PR TITLE
tweak efficientnet/utils.py import to match upstream

### DIFF
--- a/models/official/efficientnet/utils.py
+++ b/models/official/efficientnet/utils.py
@@ -24,9 +24,7 @@ import sys
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.contrib.tpu.python.ops import tpu_ops
-from tensorflow.contrib.tpu.python.tpu import tpu_function
-
+from tensorflow.python.tpu.ops.tpu_ops import *
 
 def build_learning_rate(initial_lr,
                         global_step,


### PR DESCRIPTION
please check/drop this if I am doing things wrong, but i think this has been moved as of 1.14/1.15/master:

1.13
    https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/contrib/tpu/python/ops/tpu_ops.py

1.14
    https://github.com/tensorflow/tensorflow/blob/r1.14/tensorflow/contrib/tpu/python/ops/tpu_ops.py