### PR TITLE
detection bugfix: nasfpn.py

### DIFF
--- a/models/official/detection/modeling/architecture/nasfpn.py
+++ b/models/official/detection/modeling/architecture/nasfpn.py
@@ -201,7 +201,7 @@ class Nasfpn(object):
     # Number of output connections from each feat.
     num_output_connections = [0] * len(feats)
     num_output_levels = self._max_level - self._min_level + 1
-    feat_levels = range(self._min_level, self._max_level + 1)
+    feat_levels = list(range(self._min_level, self._max_level + 1))
 
     for i, sub_policy in enumerate(self._config.nodes):
       with tf.variable_scope('sub_policy{}'.format(i)):


### PR DESCRIPTION
`feat_levels` must be an (extendable) list, not a `range` object

This fixes the traceback:
```
...
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/model_builder.py", line 47, in __call__
    return self._model.train(features, labels)
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/retinanet_model.py", line 82, in train
    outputs = self.model_outputs(features, labels, mode=mode_keys.TRAIN)
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/base_model.py", line 118, in model_outputs
    outputs = self.build_outputs(features, labels, mode)
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/retinanet_model.py", line 57, in build_outputs
    backbone_features, is_training=(mode == mode_keys.TRAIN))
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/architecture/nasfpn.py", line 194, in __call__
    feats_dict = self._build_feature_pyramid(feats, is_training)
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/architecture/nasfpn.py", line 269, in _build_feature_pyramid
    feat_levels.append(new_level)
AttributeError: 'range' object has no attribute 'append'
```

I was trying to use the code with the published config: https://github.com/tensorflow/tpu/blob/master/models/official/detection/configs/yaml/retinanet_nasfpn.yaml 

There do not appear to be unit tests :( so no wonder this slipped through?