### PR TITLE
Fix bug in mapping labels

### DIFF
--- a/models/official/mnasnet/mnasnet_example.ipynb
+++ b/models/official/mnasnet/mnasnet_example.ipynb
@@ -243,7 +243,7 @@
         "print(\"Top class: \", top_class[0], \" with Probability= \", probs[0][top_class[0]])\n",
         "label_map = imagenet.create_readable_names_for_imagenet_labels()  \n",
         "for idx, label_id in enumerate(reversed(list(np.argsort(probs)[0][-5:]))):\n",
-        "  print(\"Top %d Prediction: %d, %s, probs=%f\" % (idx+1, label_id, label_map[label_id], probs[0][label_id]))\n",
+        "  print(\"Top %d Prediction: %d, %s, probs=%f\" % (idx+1, label_id, label_map[label_id+1], probs[0][label_id]))\n",
         "  "
       ],
       "execution_count": 47,
@@ -252,11 +252,11 @@
           "output_type": "stream",
           "text": [
             "Top class:  388  with Probability=  0.87763524\n",
-            "Top 1 Prediction: 388, lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens, probs=0.877635\n",
-            "Top 2 Prediction: 245, Tibetan mastiff, probs=0.002865\n",
-            "Top 3 Prediction: 384, Madagascar cat, ring-tailed lemur, Lemur catta, probs=0.002584\n",
-            "Top 4 Prediction: 296, American black bear, black bear, Ursus americanus, Euarctos americanus, probs=0.001733\n",
-            "Top 5 Prediction: 222, Irish water spaniel, probs=0.001599\n"
+            "Top 1 Prediction: 388, giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca, probs=0.877635\n",
+            "Top 2 Prediction: 245, French bulldog, probs=0.002865\n",
+            "Top 3 Prediction: 384, indri, indris, Indri indri, Indri brevicaudatus, probs=0.002584\n",
+            "Top 4 Prediction: 296, ice bear, polar bear, Ursus Maritimus, Thalarctos maritimus, probs=0.001733\n",
+            "Top 5 Prediction: 222, kuvasz, probs=0.001599\n"
           ],
           "name": "stdout"
         }


### PR DESCRIPTION
The MnasNet model predicts probabilities for 1000 classes, however, the provided imagenet module has 1001 classes, with "background" being a dummy class. Hence, label indices should be incremented by one.