### PR TITLE
detection tpu_executor.py: fix python3 bug

### DIFF
--- a/models/official/detection/executor/tpu_executor.py
+++ b/models/official/detection/executor/tpu_executor.py
@@ -16,6 +16,7 @@
 
 import collections
 import os
+import six
 
 import numpy as np
 import tensorflow as tf
@@ -145,7 +146,7 @@ class TpuExecutor(object):
         yield_single_examples=False)
     losses = collections.defaultdict(lambda: 0.0)
     for _ in range(eval_steps):
-      outputs = predictor.next()
+      outputs = six.next(predictor)
       predictions = {}
       groundtruths = {}
       for key, val in outputs.items():


### PR DESCRIPTION
Evaluation for detection currently crashes when using python3.  Tested manually, because this repo has no unit tests 🙀 

Also very frustrating, but not in this PR: segfault upon `executor.prepare_evaluation()` if there's no eval json file and no eval file pattern is set.  I tried gdb and the segafault is within the `tf.data.Dataset` and not easy to decipher.  There should probably be a guard against unexpected configuration within `executor.prepare_evaluation()`, but I leave the design of such guard to the Google maintainers.  

@allenwang28  Could you please apply this fix internally and push to `master`?  