### PR TITLE
Fix typo in tf.data.Datset

### DIFF
--- a/tools/colab/keras_mnist_tpu.ipynb
+++ b/tools/colab/keras_mnist_tpu.ipynb
@@ -64,7 +64,7 @@
         "\n",
         "This sample trains an \"MNIST\" handwritten digit \n",
         "recognition model on a GPU or TPU backend using a Keras\n",
-        "model. Data are handled using the tf.data.Datset API. This is\n",
+        "model. Data are handled using the tf.data.Dataset API. This is\n",
         "a very simple sample provided for educational purposes. Do\n",
         "not expect outstanding TPU performance on a dataset as\n",
         "small as MNIST.\n",


### PR DESCRIPTION
- Fix typo in `tf.data.Datset` → `tf.data.Dataset`.