### PR TITLE
[fix] efficientnet input tensor shape error when num_label_classes == 1001

### DIFF
--- a/models/official/efficientnet/imagenet_input.py
+++ b/models/official/efficientnet/imagenet_input.py
@@ -95,8 +95,6 @@ class ImageNetTFExampleInput(object):
     self.image_size = image_size
     self.include_background_label = include_background_label
     self.num_label_classes = num_label_classes
-    if include_background_label:
-      self.num_label_classes += 1
     self.augment_name = augment_name
     self.mixup_alpha = mixup_alpha
     self.randaug_num_layers = randaug_num_layers


### PR DESCRIPTION
Fix an shape error when num_label_classes == 1001

> ... ...
>   File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/losses/losses_impl.py", line 766, in softmax_cross_entropy
>     logits.get_shape().assert_is_compatible_with(onehot_labels.get_shape())
>   File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/tensor_shape.py", line 1103, in assert_is_compatible_with
>     raise ValueError("Shapes %s and %s are incompatible" % (self, other))
> ValueError: Shapes (64, 1001) and (64, 1002) are incompatible