### PR TITLE
[fix]tf version error in efficientnet export model script 

### DIFF
--- a/models/official/efficientnet/export_model.py
+++ b/models/official/efficientnet/export_model.py
@@ -113,6 +113,8 @@ def main(_):
   # Enables eager context for TF 1.x. TF 2.x will use eager by default.
   # This is used to conveniently get a representative dataset generator using
   # TensorFlow training input helper.
+  (MAJOR, MINOR, PATCH) = map(int, tf.VERSION.split('.'))
+
   tf.enable_eager_execution()
 
   model_builder = get_model_builder(FLAGS.model_name)
@@ -149,6 +151,10 @@ def main(_):
     converter = tf.lite.TFLiteConverter.from_session(sess, [images],
                                                      [output_tensor])
     if FLAGS.quantize:
+      if MAJOR<=1 and MINOR<15:
+        raise AssertionError("Post training quantization requires "
+            "TensorFlow version >= 1.15")
+
       if not FLAGS.data_dir:
         raise ValueError(
             "Post training quantization requires data_dir flag to point to the "


### PR DESCRIPTION
tf.lite.TFLiteConverter.target_spec was not introduced until version [1.15.0](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/lite/TargetSpec)
this PR added tf version check when FLAGS.quantize == True
the problem mentioned in issue #492 should be fixed.