### PR TITLE
retinanet - Bug fix for single node CPU/GPU training

### DIFF
--- a/models/official/retinanet/retinanet_main.py
+++ b/models/official/retinanet/retinanet_main.py
@@ -353,6 +353,7 @@ def main(argv):
         resnet_checkpoint=FLAGS.resnet_checkpoint,
         val_json_file=FLAGS.val_json_file,
         mode=FLAGS.mode,
+        auto_mixed_precision=FLAGS.auto_mixed_precision,
     )
     tpu_config = tf.contrib.tpu.TPUConfig(
         FLAGS.iterations_per_loop,


### PR DESCRIPTION
When running single node training for RetinaNet on CPU or GPU there is a key error during training at: https://github.com/tensorflow/tpu/blob/master/models/official/retinanet/retinanet_model.py#L465

After adding 'auto_mixed_precision' to the TPUEstimator 'params', model training runs successfully on a single node with CPU/GPU. 