### PR TITLE
fix one typo in doc

### DIFF
--- a/models/official/efficientnet/preprocessing.py
+++ b/models/official/efficientnet/preprocessing.py
@@ -137,7 +137,7 @@ def _flip(image):
 def preprocess_for_train(image_bytes, use_bfloat16, image_size=IMAGE_SIZE,
                          augment_name=None,
                          randaug_num_layers=None, randaug_magnitude=None):
-  """Preprocesses the given image for evaluation.
+  """Preprocesses the given image for training.
 
   Args:
     image_bytes: `Tensor` representing an image binary of arbitrary size.


### PR DESCRIPTION
code author use "prepare image for evaluation" in the `preprocess_for_train` func.