### PR TITLE
Fix python3 bug in retinanet_model.py

### DIFF
--- a/models/official/detection/modeling/retinanet_model.py
+++ b/models/official/detection/modeling/retinanet_model.py
@@ -63,7 +63,7 @@ class RetinanetModel(base_model.Model):
     }
 
     # Print number of parameters and FLOPS in model.
-    batch_size, _, _, _ = backbone_features.values()[0].get_shape().as_list()
+    batch_size, _, _, _ = list(backbone_features.values())[0].get_shape().as_list()
     benchmark_utils.compute_model_statistics(
         batch_size, is_training=(mode == mode_keys.TRAIN))
 


### PR DESCRIPTION
Traceback:
```
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/base_model.py", line 122, in model_outputs
    outputs = self.build_outputs(features, labels, mode)
  File "/opt/au/external/tensorflow_tpu/models/official/detection/modeling/retinanet_model.py", line 66, in build_outputs
    batch_size, _, _, _ = backbone_features.values()[0].get_shape().as_list()
TypeError: 'dict_values' object does not support indexing
```

@allenwang28 