### PR TITLE
Add explicit tensorflow version to fashion_mnist.ipynb

### DIFF
--- a/tools/colab/fashion_mnist.ipynb
+++ b/tools/colab/fashion_mnist.ipynb
@@ -151,6 +151,7 @@
       },
       "outputs": [],
       "source": [
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "import numpy as np\n",
         "\n",


### PR DESCRIPTION
Colab will soon update the default version of tensorflow to 2.1.0. In order for this notebook to continue to work, I'm adding a line magic that will ensure this notebook continues to use tensorflow 1.x and execute without errors.