### PR TITLE
Add explicit tensorflow version to bert_finetuning_with_cloud_tpus.ipynb

### DIFF
--- a/tools/colab/bert_finetuning_with_cloud_tpus.ipynb
+++ b/tools/colab/bert_finetuning_with_cloud_tpus.ipynb
@@ -167,6 +167,7 @@
         "import random\n",
         "import string\n",
         "import sys\n",
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "\n",
         "assert 'COLAB_TPU_ADDR' in os.environ, 'ERROR: Not connected to a TPU runtime; please see the first cell in this notebook for instructions!'\n",


### PR DESCRIPTION
Colab will soon update the default version of tensorflow to 2.1.0. In order for this notebook to continue to work, I'm adding a line magic that will ensure this notebook continues to use tensorflow 1.x and execute without errors.