### PR TITLE
imagenet_to_gcs.py: Close session on deletion of ImageCoder object

### DIFF
--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -251,6 +251,9 @@ class ImageCoder(object):
     self._decode_jpeg_data = tf.placeholder(dtype=tf.string)
     self._decode_jpeg = tf.image.decode_jpeg(self._decode_jpeg_data, channels=3)
 
+  def __del__(self):
+    self._sess.close()
+
   def png_to_jpeg(self, image_data):
     return self._sess.run(self._png_to_jpeg,
                           feed_dict={self._png_data: image_data})


### PR DESCRIPTION
This PR fixes a minor bug in the ImageCoder object of imagenet_to_gcs.py. When an ImageCoder object is deleted, it should call `self._sess.close()`.

(It's arguably not a big deal since this is just a preprocessing script. But I noticed the issue when copying that class into my own codebase.)