### PR TITLE
ResNet - Bug fix for retraining from saved checkpoints

### DIFF
--- a/models/official/resnet/resnet_main.py
+++ b/models/official/resnet/resnet_main.py
@@ -680,8 +680,8 @@ def main(unused_argv):
 
   else:   # FLAGS.mode == 'train' or FLAGS.mode == 'train_and_eval'
     try:
-      current_step = tf.train.load_variable(FLAGS.model_dir,
-                                            tf.GraphKeys.GLOBAL_STEP)
+      current_step = int(tf.train.load_variable(FLAGS.model_dir,
+                                                tf.GraphKeys.GLOBAL_STEP))
     except (TypeError, ValueError, tf.errors.NotFoundError):
       current_step = 0
     steps_per_epoch = params.num_train_images // params.train_batch_size


### PR DESCRIPTION
There is a bug with the ResNet repo when re-training a model with the saved checkpoints from a previous run. 

The error occurs at https://github.com/tensorflow/tpu/blob/master/models/official/resnet/resnet_main.py#L728 with the message `TypeError: Train max_steps must be int, got <class 'numpy.int64'>`

When the global step is imported from the saved checkpoints (https://github.com/tensorflow/tpu/blob/master/models/official/resnet/resnet_main.py#L683), it's an instance of the `numpy.int64` type which causes the error. Converting the `current_step` var to `int` fixes this issue, and allows a model to be trained from saved checkpoints.