### PR TITLE
Update imagenet_to_gcs.py

### DIFF
--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -367,7 +367,7 @@ def convert_to_tf_records(raw_data_dir):
   random.seed(0)
   def make_shuffle_idx(n):
     order = range(n)
-    random.shuffle(order)
+    random.shuffle(list(order))
     return order
 
   # Glob all the training files


### PR DESCRIPTION
The error was raised when I run this file: TypeError: 'range' object does not support item assignment. 
I found that there is no way to rearrange elements in a range object in Python 3 because 'range'  does not return a list. 
Convert it to a list before shuffling is ok.