### PR TITLE
Update fashion_mnist notebook to TensorFlow 2.2.0-rc2

### DIFF
--- a/tools/colab/fashion_mnist.ipynb
+++ b/tools/colab/fashion_mnist.ipynb
@@ -237,9 +237,10 @@
       "source": [
         "import os\n",
         "\n",
-        "resolver = tf.contrib.cluster_resolver.TPUClusterResolver('grpc://' + os.environ['COLAB_TPU_ADDR'])\n",
-        "tf.contrib.distribute.initialize_tpu_system(resolver)\n",
-        "strategy = tf.contrib.distribute.TPUStrategy(resolver)\n",
+        "resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu='grpc://' + os.environ['COLAB_TPU_ADDR'])\n",
+        "tf.config.experimental_connect_to_cluster(resolver)\n",
+        "tf.tpu.experimental.initialize_tpu_system(resolver)\n",
+        "strategy = tf.distribute.experimental.TPUStrategy(resolver)\n",
         "\n",
         "with strategy.scope():\n",
         "  model = create_model()\n",


### PR DESCRIPTION
Traceback:
```
      1 import os
      2 
----> 3 resolver = tf.contrib.cluster_resolver.TPUClusterResolver('grpc://' + os.environ['COLAB_TPU_ADDR'])
      4 tf.contrib.distribute.initialize_tpu_system(resolver)
      5 strategy = tf.contrib.distribute.TPUStrategy(resolver)

AttributeError: module 'tensorflow' has no attribute 'contrib'
```

@allenwang28 