### PR TITLE
Fix mean value calculation in contrast

### DIFF
--- a/models/official/efficientnet/autoaugment.py
+++ b/models/official/efficientnet/autoaugment.py
@@ -206,7 +206,9 @@ def contrast(image, factor):
   # and create a constant image size of that value.  Use that as the
   # blending degenerate target of the original image.
   hist = tf.histogram_fixed_width(degenerate, [0, 255], nbins=256)
-  mean = tf.reduce_sum(tf.cast(hist, tf.float32)) / 256.0
+  counts = tf.size(degenerate)
+  normalized_hist = tf.cast(hist, tf.float32) / tf.cast(counts, tf.float32)
+  mean = tf.reduce_sum(normalized_hist * tf.range(256, dtype=tf.float32))
   degenerate = tf.ones_like(degenerate, dtype=tf.float32) * mean
   degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
   degenerate = tf.image.grayscale_to_rgb(tf.cast(degenerate, tf.uint8))


### PR DESCRIPTION
The mean value calculation using an histogram was broken. It counted the number of pixels and divided this value by 256.
The correct mean value is now calculated by normalizing the histogram and taking the sum of all relative bin counts multiplied by their index.