### PR TITLE
Erased spaces on last line: final cell would not run

### DIFF
--- a/tools/colab/fashion_mnist.ipynb
+++ b/tools/colab/fashion_mnist.ipynb
@@ -312,8 +312,8 @@
         "    axes[x, y].imshow(images[i])\n",
         "    axes[x, y].text(0.5, 0.5, label + '\\n%.3f' % confidence, fontsize=14)\n",
         "\n",
-        "  pyplot.gcf().set_size_inches(8, 8)  \n",
-        "  plot_predictions(np.squeeze(x_test[:16]), cpu_model.predict(x_test[:16]))"
+        "pyplot.gcf().set_size_inches(8, 8)  \n",
+        "plot_predictions(np.squeeze(x_test[:16]), cpu_model.predict(x_test[:16]))"
       ]
     },
     {


### PR DESCRIPTION
Final cell would not run because last cell called the function inside the definition of that function.  I deleted spaces, removing the function call from the definition of the function, and the last cell works now.