### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/models/official/detection/modeling/architecture/nn_ops.py
+++ b/models/official/detection/modeling/architecture/nn_ops.py
@@ -41,7 +41,7 @@ class BatchNormalization(tf.layers.BatchNormalization):
   def __init__(self, fused=False, max_shards_for_local=8, **kwargs):
     """Builds the batch normalization layer.
 
-    Arguments:
+    Args:
       fused: If `False`, use the system recommended implementation. Only support
         `False` in the current implementation.
       max_shards_for_local: The maximum number of TPU shards that should use

--- a/models/official/efficientnet/condconv/condconv_layers.py
+++ b/models/official/efficientnet/condconv/condconv_layers.py
@@ -36,7 +36,7 @@ def get_condconv_initializer(initializer, num_experts, expert_shape):
   is correctly initialized with the given initializer before being flattened
   into the correctly shaped CondConv variable.
 
-  Arguments:
+  Args:
     initializer: The initializer to apply for each individual expert.
     num_experts: The number of experts to be initialized.
     expert_shape: The original shape of each individual expert.

--- a/models/official/efficientnet/imagenet_input.py
+++ b/models/official/efficientnet/imagenet_input.py
@@ -137,7 +137,7 @@ class ImageNetTFExampleInput(six.with_metaclass(abc.ABCMeta, object)):
       Mixup: Beyond Empirical Risk Minimization.
       ICLR'18, https://arxiv.org/abs/1710.09412
 
-    Arguments:
+    Args:
       batch_size: The input batch size for images and labels.
       alpha: Float that controls the strength of Mixup regularization.
       images: A batch of images of shape [batch_size, ...]

--- a/models/official/mask_rcnn/distributed_executer.py
+++ b/models/official/mask_rcnn/distributed_executer.py
@@ -71,7 +71,7 @@ class DistributedExecuter(object):
   def build_mask_rcnn_estimator(self, params, run_config, mode):
     """Creates TPUEstimator/Estimator instance.
 
-    Arguments:
+    Args:
       params: A dictionary to pass to Estimator `model_fn`.
       run_config: RunConfig instance specifying distribution strategy
         configurations.

--- a/models/official/mask_rcnn/tpu_normalization.py
+++ b/models/official/mask_rcnn/tpu_normalization.py
@@ -94,7 +94,7 @@ def cross_replica_batch_normalization(inputs,
   For detailed information of arguments and implementation, refer to:
   https://www.tensorflow.org/api_docs/python/tf/keras/layers/BatchNormalization
 
-  Arguments:
+  Args:
     inputs: Tensor input.
     training: Either a Python boolean, or a TensorFlow boolean scalar tensor
       (e.g. a placeholder). Whether to return the output in training mode


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420