### PR TITLE
Update imagenet_to_gcs.py

### DIFF
--- a/tools/datasets/imagenet_to_gcs.py
+++ b/tools/datasets/imagenet_to_gcs.py
@@ -348,7 +348,7 @@ def convert_to_tf_records(
 
   # Glob all the validation files
   validation_files = sorted(tf.gfile.Glob(
-      os.path.join(raw_data_dir, VALIDATION_DIRECTORY, '*', '.JPEG')))
+      os.path.join(raw_data_dir, VALIDATION_DIRECTORY, '*.JPEG')))
 
   # Get validation file synset labels from labels.txt
   validation_synsets = tf.gfile.FastGFile(


### PR DESCRIPTION
The expected validation file formats are
`validation/ILSVRC2012_val_00000001.JPEG`

The current validation glob is
`validation/*/.JPEG`
Note that there is a slash between the `*` and `.JPEG` which is incorrect, and the resulting glob will be an empty list.

By changing the glob to `*.JPEG` instead of `*`,`'.JPEG`, we remove the slash.

I did this myself when following the imagined GCS [guide](https://cloud.google.com/tpu/docs/imagenet-setup), and it worked for me