### PR TITLE
fix(docs): corrects typos in project documentation

### DIFF
--- a/models/official/resnet/resnet_rs/README.md
+++ b/models/official/resnet/resnet_rs/README.md
@@ -45,7 +45,7 @@ We release configs and checkpoints of the ResNet-RS model family trained on Imag
 *  Latencies on TPUv3 are measured using `bfloat16` precision.
 *  All latencies are measured with an initial training batch size of 128 images, which is divided by 2 until it fits onto the accelerator.
 
-Code and checkpoints are avaliable in Tensorflow 2 at the official Tensorflow [Model Garden](https://github.com/tensorflow/models/tree/master/official/vision/beta).
+Code and checkpoints are available in Tensorflow 2 at the official Tensorflow [Model Garden](https://github.com/tensorflow/models/tree/master/official/vision/beta).
 
 ## Citation
 ```make

--- a/tools/ctpu/README.md
+++ b/tools/ctpu/README.md
@@ -226,7 +226,7 @@ It will be most helpful if you include:
 
 ### Developing ###
 
-The code is layed out in the following packages:
+The code is laid out in the following packages:
 
  - **`config`**: This package contains the tool-wide configuration, such as (1)
    the credentials used to communicate with GCP, (2) desired zone, and (3) the


### PR DESCRIPTION
Scope of changes is restricted to docs only.