### PR TITLE
RayTpuController init() cleanup

### DIFF
--- a/tools/ray_tpu/src/ipp_tool.py
+++ b/tools/ray_tpu/src/ipp_tool.py
@@ -160,7 +160,6 @@ def main(_):
         accelerator_type='V4',
         accelerator_topology=FLAGS.tpu_topology,
         version='tpu-vm-v4-base',
-        head_addr=f'{get_controller_ip()}:{_DEFAULT_RAY_PORT}',
         preemptible=FLAGS.preemptible,
     )
     controllers.append(controller)

--- a/tools/ray_tpu/src/ray_tpu_controller.py
+++ b/tools/ray_tpu/src/ray_tpu_controller.py
@@ -93,17 +93,14 @@ class RayTpuController(tpu_controller.TPUController):
       tpu_name: str,
       startup_script: Optional[List[str]] = None,
       runtime_env: Optional[RayRuntimeEnv] = None,
-      head_addr: Optional[str] = None,
       **kwargs,
   ):
     if not ray.is_initialized():
       if runtime_env:
-        result = ray.init(runtime_env=dataclasses.asdict(runtime_env))
+        ray.init(runtime_env=dataclasses.asdict(runtime_env))
       else:
-        result = ray.init()
-      self._head_addr = result.address_info["address"]
-    if head_addr:
-      self._head_addr = head_addr
+        ray.init()
+    self._head_addr = ray.get_runtime_context().gcs_address
     self.resource_name = f"{tpu_name}_tpu_host"
     ray_setup = self.get_ray_setup_commands()
     self._job_client = None


### PR DESCRIPTION
`head_addr` is no longer needed as an optional function argument it can be obtained from the ray cluster after initialization using `ray.get_runtime_context().gcs_address`

Tested this change with `run_basic_jax.py`.