### PR TITLE
Updating the v5e example of GKE to provision eight VLP pools

### DIFF
--- a/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
+++ b/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
@@ -1,4 +1,4 @@
-project_id           = "project_id"
+roject_id            = "project_id"
 resource_name_prefix = "tpu-v5e-test"
 region               = "us-east5"
 tpu_node_pools = [{
@@ -25,5 +25,29 @@ tpu_node_pools = [{
   machine_type = "ct5lp-hightpu-4t"
   topology     = "16x16"
   policy       = "sb-compact-1"
-  }]
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-1"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-1"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-1"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-1"
+}]
 maintenance_interval = "PERIODIC"

--- a/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
+++ b/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
@@ -1,4 +1,4 @@
-roject_id            = "project_id"
+project_id           = "project_id"
 resource_name_prefix = "tpu-v5e-test"
 region               = "us-east5"
 tpu_node_pools = [{


### PR DESCRIPTION
* Update the v5e example TF of GKE from four to eight VLP pools;

Notes:
- The workflow of 8 VLP pods has been verified by @yangyuwei internally.
- Please combine the commits (unify), Thanks!