### PR TITLE
Updating the v5e example of GKE terraform for 16 VLP pods

### DIFF
--- a/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
+++ b/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
@@ -1,4 +1,4 @@
-roject_id            = "project_id"
+project_id           = "project_id"
 resource_name_prefix = "tpu-v5e-test"
 region               = "us-east5"
 tpu_node_pools = [{

--- a/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
+++ b/tools/kubernetes/terraform/examples/v5e/terraform.tfvars
@@ -1,4 +1,4 @@
-project_id           = "project_id"
+roject_id            = "project_id"
 resource_name_prefix = "tpu-v5e-test"
 region               = "us-east5"
 tpu_node_pools = [{
@@ -6,24 +6,96 @@ tpu_node_pools = [{
   node_count   = 64
   machine_type = "ct5lp-hightpu-4t"
   topology     = "16x16"
-  policy       = "sb-compact-1"
+  policy       = "sb-compact-4a"
   }, {
   zone         = "us-east5-b"
   node_count   = 64
   machine_type = "ct5lp-hightpu-4t"
   topology     = "16x16"
-  policy       = "sb-compact-1"
+  policy       = "sb-compact-4a"
   }, {
   zone         = "us-east5-b"
   node_count   = 64
   machine_type = "ct5lp-hightpu-4t"
   topology     = "16x16"
-  policy       = "sb-compact-1"
+  policy       = "sb-compact-4a"
   }, {
   zone         = "us-east5-b"
   node_count   = 64
   machine_type = "ct5lp-hightpu-4t"
   topology     = "16x16"
-  policy       = "sb-compact-1"
-  }]
+  policy       = "sb-compact-4a"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4b"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4b"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4b"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4b"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4c"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4c"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4c"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4c"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4d"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4d"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4d"
+  }, {
+  zone         = "us-east5-b"
+  node_count   = 64
+  machine_type = "ct5lp-hightpu-4t"
+  topology     = "16x16"
+  policy       = "sb-compact-4d"
+}]
 maintenance_interval = "PERIODIC"


### PR DESCRIPTION
* Update the v5e example TF of GKE to provision 16 VLP pools.

Notes:
- The workflow of 16 VLP pods across 4 super-blocks has been verified by @yangyuwei internally.
- Hi Reviewer(s), please combine the commits (unify), Thanks!