### PR TITLE
docs: improve README clarity for PYTHONPATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please file an issue if you have a feature or bug request.
 To run models in the `models` subdirectory, you may need to add the top-level
 `/models` folder to the Python path with the command:
 
-```
+```bash
 export PYTHONPATH="$PYTHONPATH:/path/to/models"
 ```
+
+Replace `/path/to/models` with the actual path to your cloned repository.


### PR DESCRIPTION
Minor documentation improvement to clarify PYTHONPATH setup instructions.

## Changes
- Add bash syntax highlighting to code block
- Add clarification note about replacing placeholder path

*Note: This is a test PR to verify the contribution workflow.*